### PR TITLE
Lowercase the debugging package name to appease VSCode

### DIFF
--- a/Data/debug-html5/package.json
+++ b/Data/debug-html5/package.json
@@ -1,5 +1,5 @@
 {
-  "name"    : "KodeStudio-Debug",
+  "name"    : "kodestudio-debug",
   "version" : "0.1.0",
   "main"    : "electron.js"
 }


### PR DESCRIPTION
VSCode has updated, and as such it is now annoyed at big letters in package.jsons. Let's make them smaller so we don't see a warning in the problem panel anymore when we have a built project lying around.